### PR TITLE
feat: conditional comments detection

### DIFF
--- a/src/soup.coffee
+++ b/src/soup.coffee
@@ -5,8 +5,9 @@ Attribute = require './attribute'
 
 module.exports = class Soup
 
-  constructor: (_string) ->
+  constructor: (_string, _options) ->
     @_string = _string.toString()
+    @_options = _options || {}
 
   _build: ->
     # This constructor builds the _$ref document and the _elements hash, which together allow finding elements in the markup string by CSS selector.
@@ -83,7 +84,7 @@ module.exports = class Soup
 
       oncomment: (comment) =>
         # if conditional comments
-        if comment.match(/^\[[\S+\s+]*]>[[\S+\s+]*<!\[[\S+\s+]*]$/)
+        if comment.match(/^\[[\S+\s+]*]>[[\S+\s+]*<!\[[\S+\s+]*]$/) && @_options.cc
           # initialize a new parser for the comment only
           comment_parser = new htmlparser.Parser
             onopentag: (tagName, attributes) =>

--- a/test/soup_test.coffee
+++ b/test/soup_test.coffee
@@ -72,6 +72,77 @@ module.exports =
         test.strictEqual li2Content, 'Item 2\n  '
         test.done()
 
+      'establishes correct indexes even when closing tags are omitted and conditional comments are set': (test) ->
+        html = """
+        <head>
+          <title>Test</title>
+          <!--[if IE]>
+            <link rel="stylesheet" type="text/css" href="style.css" />
+          <![endif]-->
+        <body>
+        <ul>
+          <li>Item 1
+          <li>Item 2
+          <li>Item 3
+        </ul>
+        """
+
+        soup = new Soup html
+        soup._build()
+
+        head = soup._elements[1]
+        title = soup._elements[2]
+        link = soup._elements[3]
+        body = soup._elements[4]
+        ul = soup._elements[5]
+        li1 = soup._elements[6]
+        li2 = soup._elements[7]
+        li3 = soup._elements[8]
+
+        linkTag = html.substring link.start, link.contentStart
+        test.strictEqual linkTag, '<link rel="stylesheet" type="text/css" href="style.css" />'
+
+        headContent = html.substring head.contentStart, head.contentEnd
+        test.strictEqual headContent, '\n  <title>Test</title>\n  <!--[if IE]>\n    <link rel="stylesheet" type="text/css" href="style.css" />\n  <![endif]-->\n'
+
+        li2Content = html.substring li2.contentStart, li2.contentEnd
+        test.strictEqual li2Content, 'Item 2\n  '
+
+        test.done()
+
+      'establishes correct indexes and ignore wrong cc': (test) ->
+        html = """
+        <head>
+          <title>Test</title>
+          <!--[if IE>
+            <link rel="stylesheet" type="text/css" href="style.css" />
+          <!endif]-->
+        <body>
+        <ul>
+          <li>Item 1</li>
+        </ul>
+        """
+
+        soup = new Soup html
+        soup._build()
+
+        head = soup._elements[1]
+        title = soup._elements[2]
+        body = soup._elements[3]
+        ul = soup._elements[4]
+        li = soup._elements[5]
+
+        titleContent = html.substring title.contentStart, title.contentEnd
+        test.strictEqual titleContent, 'Test'
+
+        bodyContent = html.substring body.start, body.end
+        test.strictEqual bodyContent, '\n<ul>\n  <li>Item 1</li>\n</ul>'
+
+        liContent = html.substring li.contentStart, li.contentEnd
+        test.strictEqual liContent, 'Item 1'
+
+        test.done()
+
     '#_select':
       'selects all the right elements': (test) ->
         html = '<img><br hi><br><p>Hi</p>'

--- a/test/soup_test.coffee
+++ b/test/soup_test.coffee
@@ -87,7 +87,8 @@ module.exports =
         </ul>
         """
 
-        soup = new Soup html
+        options = { cc: true }
+        soup = new Soup html, options
         soup._build()
 
         head = soup._elements[1]
@@ -101,6 +102,40 @@ module.exports =
 
         linkTag = html.substring link.start, link.contentStart
         test.strictEqual linkTag, '<link rel="stylesheet" type="text/css" href="style.css" />'
+
+        headContent = html.substring head.contentStart, head.contentEnd
+        test.strictEqual headContent, '\n  <title>Test</title>\n  <!--[if IE]>\n    <link rel="stylesheet" type="text/css" href="style.css" />\n  <![endif]-->\n'
+
+        li2Content = html.substring li2.contentStart, li2.contentEnd
+        test.strictEqual li2Content, 'Item 2\n  '
+
+        test.done()
+
+      'establishes correct indexes even when closing tags are omitted and conditional comments are set and options.cc are not set': (test) ->
+        html = """
+        <head>
+          <title>Test</title>
+          <!--[if IE]>
+            <link rel="stylesheet" type="text/css" href="style.css" />
+          <![endif]-->
+        <body>
+        <ul>
+          <li>Item 1
+          <li>Item 2
+          <li>Item 3
+        </ul>
+        """
+
+        soup = new Soup html
+        soup._build()
+
+        head = soup._elements[1]
+        title = soup._elements[2]
+        body = soup._elements[3]
+        ul = soup._elements[4]
+        li1 = soup._elements[5]
+        li2 = soup._elements[6]
+        li3 = soup._elements[7]
 
         headContent = html.substring head.contentStart, head.contentEnd
         test.strictEqual headContent, '\n  <title>Test</title>\n  <!--[if IE]>\n    <link rel="stylesheet" type="text/css" href="style.css" />\n  <![endif]-->\n'


### PR DESCRIPTION
I added the detection for conditional comments. I added a own parser for comments - comments are automatically tracked by `htmlparser2` with the parser function `oncomment`. 

The problem here is, that I mainly copy pasted the normal `parser` into `comment_parser` and just changed the start- and endindex.

Unfortunately I am totally unfamiliar with coffeescript, so there may be better ways to implement that. ~Furthermore, there is not an option `cc: true` yet. Also here I wasn't sure where to implement that.~

Maybe we can tweak it?

**EDIT:**
I added the `cc` option